### PR TITLE
Add Darwin support

### DIFF
--- a/graphpath
+++ b/graphpath
@@ -361,7 +361,7 @@ device="ROUTER"
 
 OS=$(uname)
 case ${OS} in
-	FreeBSD|OpenBSD|NetBSD)
+	FreeBSD|OpenBSD|NetBSD|Darwin)
 		get_bsd
 		;;
 	Linux)


### PR DESCRIPTION
Tested lightly on Darwin, seems to work properly.  

Example output: 

```
/graphpath 10.0.11.11 10.0.12.12
+----------------------------+    +----------------------------+
| SOURCE HOST                |    | DESTINATION HOST           |
| IP:   10.0.11.11           |    | IP:  10.0.12.12            |
+----------------------------+    +----------------------------+
                  |                             |
            --+---+-----------------------------+---
              |
+----------------------------+
| ROUTER                     |
| IP:   10.207.64.1          |
| ARP:  0:10:db:ff:10:32     |
+----------------------------+
              |
+----------------------------+
| IF:   en11                 |
| MAC:  58:ef:68:e7:03:ea    |
| IP:   10.207.64.21         |
| net:  default              |
| mask: default              |
|                            |
|         THIS HOST          |
+----------------------------+
```

Happy to test other scenarios if needed.